### PR TITLE
feature/Enable Contact-us form submissions through Formspree API

### DIFF
--- a/src/CSS/ContactUs.module.css
+++ b/src/CSS/ContactUs.module.css
@@ -1,21 +1,22 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Inter&display=swap");
 
-.Heading{
+.Heading {
     letter-spacing: 0px;
     font-size: 40px;
     font-weight: bold;
     font-family: "Poppins", sans-serif;
     text-align: center;
-    
+
 }
 
-::placeholder, :placeholder-shown {
+::placeholder,
+:placeholder-shown {
     font-family: "Inter", sans-serif;
     font-size: 1.2rem;
 }
 
-.Button{
+.Button {
     background-color: #008dc8;
     border: none;
     color: #fff;
@@ -32,8 +33,14 @@
     box-shadow: 5px 10px 20px -8px rgba(0, 0, 0, 0.7);
 }
 
-.Button:hover, .Button:focus, .Button:active{
+.Button:hover,
+.Button:focus,
+.Button:active {
     background-color: #008dc8;
     padding-right: 30px;
     padding-left: 30px;
+}
+
+textarea {
+    resize: none;
 }

--- a/src/Components/HomePage/Sections/ContactUs.js
+++ b/src/Components/HomePage/Sections/ContactUs.js
@@ -1,4 +1,5 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
+import axios from 'axios';
 import {
   Jumbotron,
   Container,
@@ -10,61 +11,99 @@ import {
 import styles from "../../../CSS/ContactUs.module.css";
 
 export default function ContactUs() {
-    return (
-      <Jumbotron
-        id="contact"
-        style={{ paddingTop: "0px", backgroundColor: "#ffffff" }}
-      >
-        <Container fluid="sm">
-          <h1 className={styles.Heading}>
-            Get In <span style={{ color: "#008dc8" }}>Touch</span>
-          </h1>
-          <Row
-            className="justify-content-md-center"
-            style={{ marginTop: "50px" }}
-          >
-            <Col lg={5}>
-              <Form >
-                <Form.Group>
-                  <Form.Control
-                    type="text"
-                    name="name"
-                    defaultValue=""
-                    placeholder="John Doe"
-                  />
-                </Form.Group>
-                <Form.Group controlId="formBasicEmail">
-                  <Form.Control
-                    type="email"
-                    name="email"
-                    defaultValue=""
-                    placeholder="john@example.com"
-                    required
-                  />
-                </Form.Group>
-                <Form.Group>
-                  <Form.Control
-                    as="textarea"
-                    rows="3"
-                    name="message"
-                    defaultValue=""
-                    placeholder="Message"
-                    required
-                  />
-                </Form.Group>
-                <Form.Group>
-                  <Button
-                
-                    className={styles.Button}
-                    type="submit"
-                  >
-                    Send Message
-                  </Button>
-                </Form.Group>
-              </Form>
-            </Col>
-          </Row>
-        </Container>
-      </Jumbotron>
-    );
+
+  const [serverState, setServerState] = useState({
+    submitting: false,
+    status: null
+  })
+
+  const handleServerResponse = (ok, msg, form) => {
+    setServerState({
+      submitting: false,
+      status: { ok, msg }
+    });
+    if (ok) {
+      form.reset();
+    }
   }
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    const form = e.target
+    setServerState({ submitting: true });
+    axios({
+      method: "post",
+      url: 'https://formspree.io/' + process.env.FORMSPREE_API_KEY,
+      data: new FormData(form)
+    })
+      .then(r => {
+        handleServerResponse(true, "Thanks!", form);
+      })
+      .catch(r => {
+        handleServerResponse(false, r.response.data.error, form);
+      });
+  }
+
+  return (
+    <Jumbotron
+      id="contact"
+      style={{ paddingTop: "0px", backgroundColor: "#ffffff" }}
+    >
+      <Container fluid="sm">
+        <h1 className={styles.Heading}>
+          Get In <span style={{ color: "#008dc8" }}>Touch</span>
+        </h1>
+        <Row
+          className="justify-content-md-center"
+          style={{ marginTop: "50px" }}
+        >
+          <Col lg={5}>
+            <Form onSubmit={handleSubmit}>
+              <Form.Group>
+                <Form.Control
+                  type="text"
+                  name="name"
+                  defaultValue=""
+                  placeholder="John Doe"
+                />
+              </Form.Group>
+              <Form.Group controlId="formBasicEmail">
+                <Form.Control
+                  type="email"
+                  name="email"
+                  defaultValue=""
+                  placeholder="john@example.com"
+                  required
+                />
+              </Form.Group>
+              <Form.Group>
+                <Form.Control
+                  as="textarea"
+                  rows="5"
+                  name="message"
+                  defaultValue=""
+                  placeholder="Message"
+                  required
+                />
+              </Form.Group>
+              <Form.Group>
+                <Button
+
+                  className={styles.Button}
+                  type="submit"
+                >
+                  Send Message
+                  </Button>
+                {serverState.status && (
+                  <p className={!serverState.status.ok ? "Error Msg" : ""}>
+                    {serverState.status.msg}
+                  </p>
+                )}
+              </Form.Group>
+            </Form>
+          </Col>
+        </Row>
+      </Container>
+    </Jumbotron>
+  );
+}


### PR DESCRIPTION
# Enable the contact-us form submissions through Formspree API

## @abdus before merging you only have to create a .env file at the frontend and in the .env file add 

## `FORMSPREE_API_KEY=YOUR_KEY`

## save the .env file

## After that you only have to import the .env file in the ContactUs.js file

![file-menu](https://user-images.githubusercontent.com/60239025/110987060-8eda4600-8394-11eb-87c4-b8acf5a2d6e7.png)

# Fixed #67

## I also updated the UI of the contact-us form

# Before 

![before](https://user-images.githubusercontent.com/60239025/110986584-d90ef780-8393-11eb-9c11-b70bb86becec.png)

# After UI (textarea tag get fixed) (No resizing)

![no-resizing](https://user-images.githubusercontent.com/60239025/110986631-e4fab980-8393-11eb-81a1-9edf881ac75a.png)

Please check options that are relevant to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have squashed my commits
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
